### PR TITLE
Response formatting when overriding the return response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,13 +80,19 @@ module.exports = function Validator(rules, sendResponse){
 
   /* In case of errors return a badRequest with the errors parsed */
   if(errors.length){
+    var parsedErrors = errorsParser(errors);
+    // directly send the response
     if(sendResponse){
-      var parsedErrors = errorsParser(errors);
       res.send(400, parsedErrors);
     }
-    return false;
+    return {
+      error: true,
+      message: parsedErrors
+    };
   }
 
-  return parsedParams;
-
+  return {
+    error: false
+    message:parsedParams;
+  }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ module.exports = function Validator(rules, sendResponse){
   }
 
   return {
-    error: false
-    message:parsedParams;
-  }
+    error: false,
+    message:parsedParams
+  };
 };

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,21 @@ If it can't convert or the types doesn't match, it will send the 400 error to th
   // Just set the second params as false.
   var params = req.validator(['nickname', 'email', 'password', '?name'], false);
 
-  // In case of error params === false else the params will be an object with values
-
-  if(params) return res.ok(); else return res.badRequest('Custom message');
+  // In case of error params will be equal to
+  ```
+      {
+         error: true,
+         message: "parsed errors"
+      }
+  ```
+  // Otherwise 
+  ```
+      {
+         error: false,
+         message: "will be an object with values"
+      }
+  ```
+  if(params.error) return res.ok(); else return res.badRequest('Custom message');
 
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -76,15 +76,16 @@ If it can't convert or the types doesn't match, it will send the 400 error to th
   // Just set the second params as false.
   var params = req.validator(['nickname', 'email', 'password', '?name'], false);
 
-  // In case of error params will be equal to
   ```
+    In case of error params will be equal to
+    
       {
          error: true,
          message: "parsed errors"
       }
-  ```
-  // Otherwise 
-  ```
+    
+    Otherwise : 
+    
       {
          error: false,
          message: "will be an object with values"


### PR DESCRIPTION
When overriding the validator response I find it flexible if the parsed errors can be picked up by me for a custom message.
