### PR TITLE
Fix XSS hole in validator

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -5,6 +5,7 @@
 
 var V = require('validator');
 var types = require('./validationTypes');
+var escapeHtml = require('escape-html');
 
 module.exports = function(value, validations, key){
 
@@ -44,7 +45,7 @@ var validationType = function(value, validation, key){
       return {value: value};
     }else{
       if(types[validation].type) validation = types[validation].type;
-      return {error: key + ': ' + value + ', has to be ' + validation + ' type.', param: key};
+      return {error: key + ': ' + escapeHtml(value) + ', has to be ' + validation + ' type.', param: key};
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "request-validation"
   ],
   "dependencies": {
+    "escape-html": "^1.0.3",
     "validator": "^3.26.0"
   },
   "devDependencies": {
     "sails": "^0.11.0",
     "should": "^4.4.1",
-    "mocha" : "^2.3.2"
+    "mocha": "^2.3.2"
   },
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-validator",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Validations in Sailsjs requests",
   "keywords": [
     "sails-hook",

--- a/test/bdd/05.url.test.js
+++ b/test/bdd/05.url.test.js
@@ -110,7 +110,7 @@ describe('05 UrlController Test', function(){
       err.should.be.instanceOf(Object);
       err.status.should.be.equal(400);
       err.body.should.be.instanceOf(String);
-      err.body.should.be.equal(' url: no!that\'s!not!a!web.com, has to be url type.');
+      err.body.should.be.equal(' url: no!that&#39;s!not!a!web.com, has to be url type.');
       return done();
     });
   });


### PR DESCRIPTION
Validator output is sent by an express`res.send` which is a default text/html content type. Untrusted user input can include SCRIPT tags and can be sent, fail validation, and then be echoed out.

This is a Reflected XSS Attack. https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)#Reflected_XSS_Attacks